### PR TITLE
Add default nixos configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,10 +12,16 @@
         inherit system;
         modules = [ hostPath ];
       };
+
+      laptop = mkHost ./hosts/laptop;
+      desktop = mkHost ./hosts/desktop;
     in {
       nixosConfigurations = {
-        laptop = mkHost ./hosts/laptop;
-        desktop = mkHost ./hosts/desktop;
+        laptop = laptop;
+        desktop = desktop;
+        # Provide a default configuration under the name 'nixos'
+        # so that plain `nixos-rebuild switch` works out of the box.
+        nixos = laptop;
       };
     };
 }


### PR DESCRIPTION
## Summary
- set up a `nixos` alias in the flake to allow `nixos-rebuild` to work without specifying the host

## Testing
- `bash: nix: command not found`