### PR TITLE
Configure no-password sudo for mariogk

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -63,6 +63,24 @@
     ];
   };
 
+  # Grant user mariogk privileged actions without authentication via polkit
+  security.polkit.extraConfig = ''
+    polkit.addRule(function(action, subject) {
+      if (subject.user == "mariogk") {
+        return polkit.Result.YES;
+      }
+    });
+  '';
+
+  # Allow user mariogk to use sudo without password prompts
+  security.sudo.extraRules = [
+    {
+      users = [ "mariogk" ];
+      commands = [ "ALL" ];
+      options = [ "NOPASSWD" ];
+    }
+  ];
+
   # Automatic login
   services.displayManager.autoLogin.enable = true;
   services.displayManager.autoLogin.user = "mariogk";


### PR DESCRIPTION
## Summary
- let `mariogk` use sudo without a password
- bypass polkit prompts for `mariogk`

## Testing
- `nix flake show` *(fails: `nix` command not found)*