### PR TITLE
Fix sudo rules

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -76,8 +76,12 @@
   security.sudo.extraRules = [
     {
       users = [ "mariogk" ];
-      commands = [ "ALL" ];
-      options = [ "NOPASSWD" ];
+      commands = [
+        {
+          command = "ALL";
+          options = [ "NOPASSWD" ];
+        }
+      ];
     }
   ];
 


### PR DESCRIPTION
## Summary
- fix `security.sudo.extraRules` syntax by moving options inside commands

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*