### PR TITLE
Add PowerShell and oh‑my‑posh

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -61,6 +61,7 @@
       kdePackages.kate
       thunderbird
     ];
+    shell = pkgs.powershell;
   };
 
   # Grant user mariogk privileged actions without authentication via polkit
@@ -85,6 +86,10 @@
   services.displayManager.autoLogin.enable = true;
   services.displayManager.autoLogin.user = "mariogk";
 
+  # Set PowerShell as the default shell for all users
+  users.defaultUserShell = pkgs.powershell;
+  environment.shells = with pkgs; [ powershell ];
+
   # Install firefox
   programs.firefox.enable = true;
 
@@ -100,6 +105,8 @@
     btop
     dotnet-sdk_9
     dotnet-sdk_10
+    powershell
+    oh-my-posh
   ];
 
   # Default system state version


### PR DESCRIPTION
## Summary
- install `powershell` and `oh-my-posh`
- make PowerShell the default shell for all users
- set user `mariogk` to use PowerShell by default

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`