### PR TITLE
Run Aspire workload install for dotnet

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -127,6 +127,11 @@ in
     aspnetCombined
   ];
 
+  # Ensure Aspire workload is available with the installed .NET SDKs
+  system.activationScripts.dotnet-aspire-install.text = ''
+    runuser -l mariogk -c "${dotnetCombined}/bin/dotnet workload install aspire"
+  '';
+
   # Default system state version
   system.stateVersion = "25.05";
 }


### PR DESCRIPTION
## Summary
- ensure the Aspire workload is installed whenever the system is built

## Testing
- `nix flake check` *(fails: `nix` command not found)*