### PR TITLE
Add zen browser via flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,17 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    zen-browser.url = "github:youwen5/zen-browser-flake";
+    zen-browser.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs = inputs@{ self, nixpkgs, zen-browser }:
     let
       system = "x86_64-linux";
       mkHost = hostPath: nixpkgs.lib.nixosSystem {
         inherit system;
         modules = [ hostPath ];
+        specialArgs = { inherit inputs; };
       };
 
       laptop = mkHost ./hosts/laptop;

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, inputs, ... }:
 
 let
   dotnetCombined =
@@ -125,8 +125,10 @@ in
     # dotnet
     dotnetCombined
     aspnetCombined
+    inputs.zen-browser.packages.${pkgs.system}.default
   ];
 
   # Default system state version
   system.stateVersion = "25.05";
 }
+


### PR DESCRIPTION
## Summary
- include `zen-browser-flake` as an input
- expose flake inputs to host modules
- install zen browser system wide

## Testing
- `nix flake show` *(fails: `nix` not installed)*