### PR TITLE
Install VS Code Insiders

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -7,6 +7,23 @@ let
   aspnetCombined =
     (with pkgs.dotnetCorePackages;
       combinePackages [ aspnetcore_10_0-bin aspnetcore_9_0 ]);
+
+  vscodeInsidersFhs =
+    (pkgs.vscode-with-extensions.override {
+      vscodeExtensions = with pkgs.vscode-extensions; [
+        ms-dotnettools.csdevkit
+        github.copilot
+        github.copilot-chat
+      ];
+      vscode = (pkgs.vscode.override { isInsiders = true; }).overrideAttrs (oldAttrs: rec {
+        src = builtins.fetchTarball {
+          url = "https://code.visualstudio.com/sha/download?build=insider&os=linux-x64";
+          sha256 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        };
+        version = "latest";
+        buildInputs = oldAttrs.buildInputs ++ [ pkgs.krb5 ];
+      });
+    }).fhs;
 in
 {
   # Bootloader
@@ -119,6 +136,7 @@ in
     pkgs.oh-my-posh
     pkgs.nerd-fonts.jetbrains-mono
     jetbrains.rider
+    vscodeInsidersFhs
     pkgs.legcord
     #kde
     kdePackages.kscreen


### PR DESCRIPTION
## Summary
- install Visual Studio Code Insiders system wide
- use FHS environment so extensions work
- preinstall C# Dev Kit, GitHub Chat and Copilot extensions

## Testing
- `nix flake check` *(fails: `nix` command not found)*