### PR TITLE
Use latest kernel

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -12,6 +12,8 @@ in
   # Bootloader
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
+  # Use the latest Linux kernel available in nixpkgs
+  boot.kernelPackages = pkgs.linuxPackages_latest;
 
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
 


### PR DESCRIPTION
## Summary
- use the latest kernel from nixpkgs

## Testing
- `nix flake check` *(fails: `nix` not found)*