### PR TITLE
Fix TLP conflict with power-profiles-daemon

### DIFF
--- a/modules/tlp.nix
+++ b/modules/tlp.nix
@@ -1,6 +1,8 @@
 { config, pkgs, ... }:
 {
   services.tlp.enable = true;
+  # Disable power-profiles-daemon as it conflicts with TLP
+  services.power-profiles-daemon.enable = false;
   environment.systemPackages = with pkgs; [ tlp tlpui ];
   services.tlp.extraConfig = builtins.readFile ../files/tlp.conf;
 }


### PR DESCRIPTION
## Summary
- disable `power-profiles-daemon` when enabling TLP

## Testing
- `nix flake check` *(fails: `nix: command not found`)*