### PR TITLE
Fix systemd warning for update service

### DIFF
--- a/modules/update-on-shutdown.nix
+++ b/modules/update-on-shutdown.nix
@@ -5,6 +5,7 @@
     wantedBy = [ "halt.target" "reboot.target" ];
     before = [ "shutdown.target" ];
     after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
     serviceConfig = {
       Type = "oneshot";
       ExecStart = "${pkgs.bash}/bin/bash /etc/nixos/files/update-before-shutdown.sh";


### PR DESCRIPTION
## Summary
- declare `network-online.target` as a wanted dependency for `update-nixos-before-shutdown.service`

## Testing
- `nix flake check` *(fails: `nix: command not found`)*