### PR TITLE
Manage PowerShell profile via flake

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -133,6 +133,13 @@ in
     runuser -l mariogk -c "${dotnetCombined}/bin/dotnet workload install aspire"
   '';
 
+  # Ensure the PowerShell profile in this repository is installed for the user
+  system.activationScripts.powershell-profile.text = ''
+    profileDir="/home/mariogk/.config/powershell"
+    install -Dm644 ${../powershell/profile.ps1} "$profileDir/Microsoft.PowerShell_profile.ps1"
+    chown mariogk:mariogk "$profileDir/Microsoft.PowerShell_profile.ps1"
+  '';
+
   # Default system state version
   system.stateVersion = "25.05";
 }

--- a/powershell/profile.ps1
+++ b/powershell/profile.ps1
@@ -1,0 +1,2 @@
+# Example PowerShell profile
+Write-Host "PowerShell profile loaded from git repo"


### PR DESCRIPTION
## Summary
- add a basic example PowerShell profile
- install that profile every time the system activates

## Testing
- `nix flake check` *(fails: `nix: command not found`)*