### PR TITLE
Set home stateVersion for mariogk

### DIFF
--- a/home/mariogk.nix
+++ b/home/mariogk.nix
@@ -11,6 +11,9 @@
 
   home.username = "mariogk";
   home.homeDirectory = "/home/mariogk";
+  # Set the version of Home Manager used for this user's configuration.
+  # This value should not be changed once initially set.
+  home.stateVersion = "24.05";
 
   programs.home-manager.enable = true;
 


### PR DESCRIPTION
## Summary
- set `home.stateVersion` in `home/mariogk.nix`

## Testing
- `nix flake show --no-update-lock-file` *(fails: `nix` command not found)*