### PR TITLE
Add pipewire lib for Qt

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -185,6 +185,8 @@ in
     dotnetCombined
     aspnetCombined
     inputs.zen-browser.packages.${pkgs.system}.default
+    # Provide libpipewire for Qt multimedia
+    pkgs.pipewire
   ];
 
   # Ensure Aspire workload is available with the installed .NET SDKs


### PR DESCRIPTION
## Summary
- make PipeWire library available system-wide for Qt apps

## Testing
- `nix flake check --no-build --impure` *(fails: `nix` not found)*