### PR TITLE
Install LACT GPU tool on desktop

### DIFF
--- a/hosts/desktop/default.nix
+++ b/hosts/desktop/default.nix
@@ -12,5 +12,6 @@
   environment.systemPackages = with pkgs; [
     amdvlk
     radeontop
+    lact
   ];
 }


### PR DESCRIPTION
## Summary
- include `lact` in desktop environment packages

## Testing
- `nix --version` *(fails: command not found)*