### PR TITLE
Fix sound support

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -82,6 +82,7 @@ in
   #};
 
   # Enable sound with pipewire.
+  sound.enable = true;
   services.pulseaudio.enable = false;
   security.rtkit.enable = true;
   services.pipewire = {


### PR DESCRIPTION
## Summary
- enable the base sound option for ALSA when using PipeWire

## Testing
- `nix flake check --show-trace` *(fails: `nix` not found)*