### PR TITLE
Remove deprecated sound option

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -82,7 +82,6 @@ in
   #};
 
   # Enable sound with pipewire.
-  sound.enable = true;
   services.pulseaudio.enable = false;
   security.rtkit.enable = true;
   services.pipewire = {


### PR DESCRIPTION
## Summary
- clean up audio configuration by removing deprecated `sound.enable` option

## Testing
- `nix build .#nixosConfigurations.laptop.config.system.build.toplevel` *(fails: `nix` command not found)*