### PR TITLE
Set NetworkManager to use iwd

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -44,6 +44,9 @@ in
     "1.1.1.1"
     "8.8.8.8"
   ];
+  # Use the iwd backend to avoid deprecated wireless extensions
+  networking.networkmanager.wifi.backend = "iwd";
+  services.iwd.enable = true;
 
   # Set your time zone
   time.timeZone = "Europe/Lisbon";


### PR DESCRIPTION
## Summary
- use iwd as NetworkManager Wi-Fi backend to avoid deprecated wireless extensions

## Testing
- `git status --short`