### PR TITLE
Enable firmware packages

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -32,6 +32,8 @@ in
   boot.kernelPackages = pkgs.linuxPackages_zen;
   # Trade security for raw performance
   boot.kernelParams = [ "mitigations=off" ];
+  # Include redistributable firmware like audio codecs
+  hardware.enableRedistributableFirmware = true;
 
   nix.settings.experimental-features = [
     "nix-command"


### PR DESCRIPTION
## Summary
- enable redistributable firmware so audio and other firmware load

## Testing
- `nixfmt modules/base.nix` *(fails: `command not found`)*