### PR TITLE
Add sof-firmware for laptop

### DIFF
--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -28,5 +28,6 @@
     intel-media-driver
     intel-compute-runtime
     intel-gpu-tools
+    sof-firmware
   ];
 }


### PR DESCRIPTION
## Summary
- include `sof-firmware` in the laptop host configuration

## Testing
- `nix flake check` *(fails: `nix` not installed)*