### PR TITLE
Fix syntax error in laptop config

### DIFF
--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -47,6 +47,8 @@ in
       libvdpau-va-gl
     ];
 
+  };
+
   environment.etc."xdg/kwinrc".text = ''
     [Compositing]
     EnableHDR=true


### PR DESCRIPTION
## Summary
- close the `hardware.graphics` block in `hosts/laptop/default.nix`

## Testing
- `nix flake check --print-build-logs` *(fails: `bash: nix: command not found`)*