### PR TITLE
Fix host module arguments

### DIFF
--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, unstablePkgs, ... }:
+{ config, lib, pkgs, unstablePkgs, ... }:
 
 let
   # Custom package for alsa-ucm-conf 1.2.14


### PR DESCRIPTION
## Summary
- import `lib` in `hosts/laptop/default.nix`

## Testing
- `nix flake check --show-trace` *(fails: `nix` command not found)*