### PR TITLE
Apply laptop audio fix

### DIFF
--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -23,6 +23,11 @@ in
 
   powerManagement.enable = true;
 
+  services.pipewire = {
+    jack.enable = true;
+    wireplumber.enable = true;
+  };
+
   environment = {
     sessionVariables.ALSA_CONFIG_UCM2 = "${alsa-ucm-conf-latest}/share/alsa/ucm2";
   };


### PR DESCRIPTION
## Summary
- remove duplicate boot and audio settings from laptop config
- enable jack and wireplumber on the laptop
- avoid duplicate `pavucontrol` package

## Testing
- `nix flake check` *(fails: `nix` not found)*