### PR TITLE
Fix unstablePkgs error in laptop host

### DIFF
--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -2,7 +2,6 @@
   config,
   lib,
   pkgs,
-  unstablePkgs,
   ...
 }:
 
@@ -71,7 +70,7 @@ in
   ];
 
   hardware.firmware = [
-    unstablePkgs.sof-firmware
+    pkgs.sof-firmware
     pkgs.alsa-firmware
   ];
 }


### PR DESCRIPTION
## Notes
- Remove the unused `unstablePkgs` argument from `hosts/laptop/default.nix`.
- Firmware uses `pkgs.sof-firmware` from the existing package set.

## Testing
- `nix` command not available in this environment so no evaluation was performed.