### PR TITLE
Enable Intel GPU via intelgpu module

### DIFF
--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -38,6 +38,12 @@ in
     sessionVariables.ALSA_CONFIG_UCM2 = "${alsa-ucm-conf-latest}/share/alsa/ucm2";
   };
 
+  # Enable the Intel GPU driver without relying on X11
+  hardware.intelgpu = {
+    driver = lib.mkIf (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.8") "xe";
+    vaapiDriver = "intel-media-driver";
+  };
+
   hardware.graphics = {
     enable = true;
     enable32Bit = true;


### PR DESCRIPTION
## Summary
- configure laptop to use Intel GPU without X11

## Testing
- `No tests defined`
