### PR TITLE
Fix modprobe patch for alsa 1.2.14

### DIFF
--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -14,6 +14,10 @@ let
       url = "mirror://alsa/lib/alsa-ucm-conf-1.2.14.tar.bz2";
       hash = "sha256-MumAn1ktkrl4qhAy41KTwzuNDx7Edfk3Aiw+6aMGnCE=";
     };
+    postPatch = ''
+      sed -i 's#/sbin/modprobe#${pkgs.kmod}/bin/modprobe#' ucm2/HDA/HDA.conf 2>/dev/null || true
+      sed -i 's#/usr/sbin/modprobe#${pkgs.kmod}/bin/modprobe#' ucm2/HDA/HDA.conf 2>/dev/null || true
+    '';
   });
 in
 {


### PR DESCRIPTION
## Summary
- patch modprobe path when building alsa-ucm-conf 1.2.14

## Testing
- `nix --version` *(fails: command not found)*