### PR TITLE
Add nixos-hardware module for laptop

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     plasma-manager.url = "github:nix-community/plasma-manager";
     plasma-manager.inputs.nixpkgs.follows = "nixpkgs";
+    nixos-hardware.url = "github:NixOS/nixos-hardware/master";
   };
 
   outputs =
@@ -18,6 +19,7 @@
       zen-browser,
       home-manager,
       plasma-manager,
+      nixos-hardware,
     }:
     let
       system = "x86_64-linux";

--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -11,6 +11,7 @@
     ../../hardware/laptop.nix
     ../../modules/tlp.nix
     ../../modules/update-on-shutdown.nix
+    inputs.nixos-hardware.nixosModules.lenovo-yoga-7-14ILL10
   ];
 
   networking.hostName = "mario-laptop";


### PR DESCRIPTION
## Summary
- include `nixos-hardware` flake input
- load the Lenovo Yoga hardware module in the laptop host config

## Testing
- `nix` command not found in container, so no tests were run