### PR TITLE
Fix laptop host inputs

### DIFF
--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }:
 


### PR DESCRIPTION
## Summary
- pass `inputs` to the laptop host so it can reference nixos-hardware

## Testing
- `nix flake show --show-trace` *(fails: `nix` not found)*