### PR TITLE
Handle dirty repo in shutdown update script

### DIFF
--- a/files/update-before-shutdown.sh
+++ b/files/update-before-shutdown.sh
@@ -5,7 +5,11 @@ cd /etc/nixos
 
 # Update configuration repository
 if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-  git pull --rebase
+  if git diff-index --quiet HEAD --; then
+    git pull --rebase
+  else
+    echo "Skipping git pull due to local changes"
+  fi
 fi
 
 # Determine flake host based on system hostname


### PR DESCRIPTION
## Summary
- skip pulling new git changes before rebuild if the repo has local modifications

## Testing
- `git log -1 --stat`