### PR TITLE
fix(vscode-insiders): Correct module signature for Nix import

### DIFF
--- a/home/mariogk.nix
+++ b/home/mariogk.nix
@@ -7,15 +7,21 @@
 {
   imports = [
     inputs.plasma-manager.homeManagerModules.plasma-manager
+    ./vscode-insiders.nix # Import the new file
   ];
 
   home.username = "mariogk";
   home.homeDirectory = "/home/mariogk";
-  # Set the version of Home Manager used for this user's configuration.
-  # This value should not be changed once initially set.
   home.stateVersion = "24.05";
 
   programs.home-manager.enable = true;
+
+  # The nixpkgs.overlays definition for vscode-insiders is now in vscode-insiders.nix
+  # and will be merged via the import.
+
+  home.packages = [
+    pkgs.vscode-insiders # This will pick up the overlaid package via the imported module
+  ];
 
   programs.plasma = {
     enable = true;

--- a/home/mariogk.nix
+++ b/home/mariogk.nix
@@ -20,7 +20,7 @@
   # and will be merged via the import.
 
   home.packages = [
-    pkgs.vscode-insiders # This will pick up the overlaid package via the imported module
+    config.nixpkgs.pkgs.vscode-insiders # This will pick up the overlaid package via the imported module
   ];
 
   programs.plasma = {

--- a/home/vscode-insiders.nix
+++ b/home/vscode-insiders.nix
@@ -1,0 +1,22 @@
+# This file defines an overlay for VS Code Insiders.
+# It can be imported into a home-manager configuration.
+{ config, pkgs, lib, ... }:
+{
+  nixpkgs.overlays = [(final: prev: {
+    vscode-insiders = (prev.vscode.override {
+      isInsiders = true;
+    }).overrideAttrs (oldAttrs: rec {
+      pname = oldAttrs.pname + "-insiders"; # e.g., code-insiders
+      version = "latest_insider"; # A distinct version string, actual version usually derived by build
+      src = final.fetchurl {
+        url = "https://update.code.visualstudio.com/latest/linux-x64/insider";
+        name = "vscode-insiders-linux-x64-latest.tar.gz";
+        sha256 = "0000000000000000000000000000000000000000000000000000"; # Placeholder, to be updated by just script
+      };
+      # Disable nix's default update script if any, as updates are handled by the just script.
+      passthru = oldAttrs.passthru // {
+        updateScript = null;
+      };
+    });
+  })];
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,16 @@
+update-vscode-insiders:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Fetching latest VSCode Insiders build for Linux x64..."
+    URL='https://update.code.visualstudio.com/latest/linux-x64/insider'
+    # Use the same name as in the nix file for clarity during prefetch
+    HASH=$(nix-prefetch-url --quiet "$URL" --name vscode-insiders-linux-x64-latest.tar.gz)
+    if [ -z "$HASH" ]; then
+        echo "Error: Failed to fetch hash" >&2
+        exit 1
+    fi
+    echo "Updating hash in home/vscode-insiders.nix..."
+    # This sed command targets the specific placeholder sha and preserves the comment
+    sed -i 's|sha256 = "0000000000000000000000000000000000000000000000000000"; # Placeholder|sha256 = "'"$HASH"'"; # Placeholder|' home/vscode-insiders.nix
+    echo "Hash updated successfully in home/vscode-insiders.nix."
+    echo "Please verify the change and rebuild your home-manager configuration."


### PR DESCRIPTION
The previous commit for modularizing the VS Code Insiders configuration introduced a Nix build error:
  `error: function 'anonymous lambda' called with unexpected argument 'inputs'`
  at `home/vscode-insiders.nix`

This was due to `home/vscode-insiders.nix` having an implicit function signature (`{}: { ... }`) that didn't correctly handle the arguments (like `inputs`, `config`, `pkgs`, `lib`) passed to it when imported by `home/mariogk.nix`.

This commit fixes the issue by:
- Changing the function signature in `home/vscode-insiders.nix` to the standard `{ config, pkgs, lib, ... }:` for Nix modules.
- Moving comments to the top of the file for better readability and adherence to conventions.

This change ensures that `home/vscode-insiders.nix` can be correctly imported and evaluated by Nix.