### PR TITLE
Refactor: Move user-specific packages and PowerShell setup to Home Ma…

### DIFF
--- a/home/mariogk.nix
+++ b/home/mariogk.nix
@@ -17,6 +17,41 @@
   programs.home-manager.enable = true;
 
   home.packages = [
+    pkgs.kdePackages.kate
+    pkgs.thunderbird # thunderbird is already in pkgs
+    pkgs.nano # nano is already in pkgs
+    pkgs.wget # wget is already in pkgs
+    pkgs.git # git is already in pkgs
+    pkgs.htop # htop is already in pkgs
+    pkgs.btop # btop is already in pkgs
+    pkgs.youtube-music
+    pkgs.zoxide
+    pkgs.oh-my-posh
+    pkgs.nerd-fonts.jetbrains-mono
+    pkgs.vorta
+    pkgs.bun
+    pkgs.jetbrains.rider # Assuming jetbrains.rider is available like this
+    pkgs.legcord
+    pkgs.nixfmt-rfc-style
+    pkgs.hunspell # hunspell is already in pkgs
+    pkgs.hunspellDicts.en_US # hunspellDicts is already in pkgs
+    pkgs.hunspellDicts.pt_BR # hunspellDicts is already in pkgs
+    pkgs.kdePackages.kscreen
+    pkgs.kdePackages.partitionmanager
+    pkgs.kdePackages.filelight
+    pkgs.kdePackages.kcalc
+    pkgs.kdePackages.kcharselect
+    pkgs.kdePackages.kcolorchooser
+    pkgs.kdePackages.kolourpaint
+    pkgs.kdePackages.ksystemlog
+    pkgs.kdePackages.sddm-kcm
+    pkgs.kdiff3 # kdiff3 is already in pkgs
+    pkgs.kdePackages.isoimagewriter
+    pkgs.hardinfo2 # hardinfo2 is already in pkgs
+    pkgs.haruna # haruna is already in pkgs
+    inputs.zen-browser.packages.${pkgs.system}.default
+    pkgs.pavucontrol # pavucontrol is already in pkgs
+    pkgs.pamixer # pamixer is already in pkgs
   ];
 
   programs.plasma = {
@@ -24,5 +59,15 @@
     workspace = {
       lookAndFeel = "org.kde.breezedark.desktop";
     };
+  };
+
+  home.activation = {
+    powershell-profile = config.lib.dag.entryAfter ["writeBoundary"] ''
+      ${pkgs.coreutils}/bin/mkdir -p "$HOME/.config/powershell"
+      ${pkgs.coreutils}/bin/install -Dm644 ../../files/powershell/profile.ps1 "$HOME/.config/powershell/Microsoft.PowerShell_profile.ps1"
+    '';
+    terminal-icons-install = config.lib.dag.entryAfter ["writeBoundary"] ''
+      ${pkgs.powershell}/bin/pwsh -NoProfile -NonInteractive -Command "if (-not (Get-Module -ListAvailable -Name Terminal-Icons)) { Install-Module -Name Terminal-Icons -Repository PSGallery -Scope CurrentUser -Force }"
+    '';
   };
 }

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -99,8 +99,6 @@
       "wheel"
     ];
     packages = with pkgs; [
-      kdePackages.kate
-      thunderbird
     ];
     shell = pkgs.powershell;
   };
@@ -143,66 +141,19 @@
 
   # Packages installed in system profile
   environment.systemPackages = with pkgs; [
-    nano
-    wget
-    git
-    htop
-    btop
-    # Media
-    pkgs.youtube-music
     # Tools
     pkgs.powershell
-    pkgs.zoxide
-    pkgs.oh-my-posh
-    pkgs.nerd-fonts.jetbrains-mono
-    pkgs.vorta
-    pkgs.bun
-    jetbrains.rider
-    pkgs.legcord
-    pkgs.nixfmt-rfc-style
-    hunspell
-    hunspellDicts.en_US
-    hunspellDicts.pt_BR
-    # KDE
-    kdePackages.kscreen
-    kdePackages.partitionmanager
-    kdePackages.filelight
-    kdePackages.kcalc
-    kdePackages.kcharselect # Tool to select and copy special characters from all installed fonts
-    kdePackages.kcolorchooser # A small utility to select a color
-    kdePackages.kolourpaint # Easy-to-use paint program
-    kdePackages.ksystemlog # KDE SystemLog Application
-    kdePackages.sddm-kcm
-    kdiff3
-    kdePackages.isoimagewriter
-    hardinfo2 # System information and benchmarks for Linux systems
-    haruna
     wayland-utils
     wl-clipboard
     libva-utils
     vulkan-tools
     powertop
-    inputs.zen-browser.packages.${pkgs.system}.default
     # Provide libpipewire for Qt multimedia
     pkgs.pipewire
     # Audio
-    pavucontrol # PulseAudio Volume Control
-    pamixer # Command-line mixer for PulseAudio
     bluez # Bluetooth support
     bluez-tools # Bluetooth tools
   ];
-
-  # Ensure the PowerShell profile in this repository is installed for the user
-  system.activationScripts.powershell-profile.text = ''
-    profileDir="/home/mariogk/.config/powershell"
-    install -Dm644 ${../files/powershell/profile.ps1} "$profileDir/Microsoft.PowerShell_profile.ps1"
-    chown mariogk "$profileDir/Microsoft.PowerShell_profile.ps1"
-  '';
-
-  # Install Terminal-Icons module for PowerShell if missing
-  system.activationScripts.terminal-icons-install.text = ''
-    runuser -l mariogk -c 'pwsh -NoProfile -NonInteractive -Command "if (-not (Get-Module -ListAvailable -Name Terminal-Icons)) { Install-Module -Name Terminal-Icons -Repository PSGallery -Scope CurrentUser -Force }"'
-  '';
 
   home-manager = {
     useGlobalPkgs = true;


### PR DESCRIPTION
…nager

This commit moves user-specific packages from the system-wide configuration (`modules/base.nix`) to the Home Manager configuration (`home/mariogk.nix`).

The following changes were made:
- Identified packages in `users.users.mariogk.packages` and `environment.systemPackages` that are better suited for user-level management.
- Moved these packages to `home.packages` in `home/mariogk.nix`.
- Relocated PowerShell profile installation and Terminal-Icons module installation from `system.activationScripts` in `modules/base.nix` to `home.activation` in `home/mariogk.nix`.
- Corrected package references in `home/mariogk.nix` (e.g., `kdePackages.foo` to `pkgs.kdePackages.foo`) and `home.activation` script paths to ensure the configuration evaluates correctly.

The NixOS configuration for the 'laptop' profile has been verified to build successfully after these changes. This promotes better separation of concerns and makes the system configuration cleaner.